### PR TITLE
The container of the helper should always appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-material-textfield",
-  "version": "0.6.2",
+  "name": "@freework/react-native-material-textfield",
+  "version": "0.7.2",
   "license": "BSD-3-Clause",
   "author": "Alexander Nazarov <n4kz@n4kz.com>",
 

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -356,12 +356,7 @@ export default class TextField extends PureComponent {
 
     let helperContainerStyle = {
       flexDirection: 'row',
-      height: (title || limit)?
-        24:
-        focus.interpolate({
-          inputRange:  [-1, 0, 1],
-          outputRange: [17, 17, 17],
-        }),
+      height: 17,
     };
 
     let labelProps = {

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -407,14 +407,14 @@ export default class TextField extends PureComponent {
           </View>
         </Animated.View>
 
-        {(title || error) && <Animated.View style={helperContainerStyle}>
+        <Animated.View style={helperContainerStyle}>
           <View style={styles.flex}>
             <Helper numberOfLines={2} style={[ errorStyle, this.props.errorStyle]}>{error}</Helper>
             <Helper numberOfLines={2} style={[ titleStyle, this.props.titleTextStyle]}>{title}</Helper>
           </View>
 
         </Animated.View>
-      }
+
       </View>
     );
   }


### PR DESCRIPTION
The container of the helper ( including error and titles ) were appearing only when there were an error or a title. 

Now I am put it back, to avoid animation and then the 82 sized input be there

https://trello.com/c/rSDxPDW5/156-general-fix-input-heights-the-last-time